### PR TITLE
Window.__init__: respect fullscreen flag

### DIFF
--- a/gltools/@src/GLFW.pxi
+++ b/gltools/@src/GLFW.pxi
@@ -104,7 +104,7 @@ cdef class Window:
         bytetext = unicode(title).encode('UTF-8','ignore')
         c_title = bytetext
         
-        self.thisptr = glfwCreateWindow(width, height, c_title, glfwGetPrimaryMonitor(), NULL)
+        self.thisptr = glfwCreateWindow(width, height, c_title, glfwGetPrimaryMonitor() if fullscreen else NULL, NULL)
         if self.thisptr == NULL:
             raise GLError('failed to open window')
         


### PR DESCRIPTION
I found that the 'fullscreen' flag was not respected.  This caused gltools to always come up full screen.  In my local testing, this change fixes the problem.